### PR TITLE
Send pairing code by email

### DIFF
--- a/dono/config.json
+++ b/dono/config.json
@@ -14,5 +14,18 @@
     "proxyAuth": {
         "username": "contactgestorvip",
         "password": "UYzqnBfusX"
+    },
+    "email": {
+        "smtp": {
+            "host": "smtp.exemplo.com",
+            "port": 587,
+            "secure": false,
+            "auth": {
+                "user": "bot@example.com",
+                "pass": "senha"
+            }
+        },
+        "from": "bot@example.com",
+        "to": "destinatario@example.com"
     }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "mongoose": "^8.10.1",
     "node-fetch": "^2.6.7",
     "os": "^0.1.1",
+    "nodemailer": "^6.9.8",
     "ping": "^0.4.4",
     "puppeteer": "^23.10.1",
     "qrcode-terminal": "^0.12.0",


### PR DESCRIPTION
## Summary
- add SMTP and recipient settings in config
- email WhatsApp pairing codes using nodemailer
- add nodemailer dependency

## Testing
- `npm install --no-audit --no-fund` *(fails: connect ENETUNREACH 140.82.113.6:443)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b24bc25ec88323b210f88687ad15db